### PR TITLE
Make CI great again!

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,6 @@ jobs:
         with:
           smalltalk-version: ${{ matrix.smalltalk }}
       - run: smalltalkci -s ${{ matrix.smalltalk }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 15


### PR DESCRIPTION
Due to the new version of the Smalltalk CI GitHub Action we have to add the GitHub secret token to the CIs environment, otherwise it fails.